### PR TITLE
Update json to ~> 2.3 for XSS vulnerability fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,14 +2,14 @@ PATH
   remote: .
   specs:
     audio_waveform-ruby (1.0.6)
-      json (~> 2.1.0)
+      json (~> 2.3)
 
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.3)
     docile (1.1.5)
-    json (2.1.0)
+    json (2.3.0)
     rake (13.0.1)
     redcarpet (3.4.0)
     rspec (3.7.0)

--- a/audio_waveform-ruby.gemspec
+++ b/audio_waveform-ruby.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.require_paths = ["lib"]
 
-  s.add_dependency 'json', '~> 2.1.0'
+  s.add_dependency 'json', '~> 2.3'
 
   s.add_development_dependency 'rake', '~> 13.0.1'
   s.add_development_dependency 'rspec', '~> 3.7.0'


### PR DESCRIPTION
From https://www.ruby-lang.org/en/news/2020/03/19/json-dos-cve-2020-10663/

> CVE-2020-10663: Unsafe Object Creation Vulnerability in JSON (Additional fix)
> Posted by mame on 19 Mar 2020
> 
> There is an unsafe object creation vulnerability in the json gem bundled with Ruby. This vulnerability has been assigned the CVE identifier CVE-2020-10663. We strongly recommend upgrading the json gem.
> 
> Details
> When parsing certain JSON documents, the json gem (including the one bundled with Ruby) can be coerced into creating arbitrary objects in the target system.
> 
> This is the same issue as CVE-2013-0269. The previous fix was incomplete, which addressed JSON.parse(user_input), but didn’t address some other styles of JSON parsing including JSON(user_input) and JSON.parse(user_input, nil).
> 
> See CVE-2013-0269 in detail. Note that the issue was exploitable to cause a Denial of Service by creating many garbage-uncollectable Symbol objects, but this kind of attack is no longer valid because Symbol objects are now garbage-collectable. However, creating arbitrary objects may cause severe security consequences depending upon the application code.
> 
> Please update the json gem to version 2.3.0 or later. You can use gem update json to update it. If you are using bundler, please add gem "json", ">= 2.3.0" to your Gemfile.
> 
> Affected versions
> JSON gem 2.2.0 or prior